### PR TITLE
Shorten the Chart description

### DIFF
--- a/riff/Chart.yaml
+++ b/riff/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
-description: riff is for functions - a FaaS built for Kubernetes
+description: riff is for functions - a FaaS for Kubernetes
 name: riff
 version: 0.0.1


### PR DESCRIPTION
- this will make the text shown during a search read better

Compare the local vs the riffrepo:

```
$ helm search faas
NAME         	VERSION	DESCRIPTION
local/riff   	0.0.1  	riff is for functions - a FaaS for Kubernetes
riffrepo/riff	0.0.1  	riff is for functions - a FaaS built for Kubern...
```

After this change the riffepo will be the same as the local