### PR TITLE
Separating the Kafka dependency into its own chart

### DIFF
--- a/kafka/.helmignore
+++ b/kafka/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/kafka/Chart.yaml
+++ b/kafka/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+description: kafka for riff
+name: kafka
+version: 0.0.1
+appVersion: 0.11.0.1
+home: https://kafka.apache.org

--- a/kafka/LICENSE
+++ b/kafka/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -1,0 +1,21 @@
+# Riff Helm Chart
+
+Single-node Kafka for riff
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm repo add riffrepo https://riff-charts.storage.googleapis.com
+$ helm repo update
+$ helm install --name my-release riffrepo/kafka
+```
+
+## Uninstalling the Release
+
+To remove the chart release with the name `my-release` and purge all the release info use:
+
+```bash
+$ helm delete --purge my-release
+```

--- a/kafka/templates/NOTES.txt
+++ b/kafka/templates/NOTES.txt
@@ -1,0 +1,3 @@
+1. Connect to the installed Kafka cluster by using:
+   Kafka broker nodes: {{ template "fullname" . }}.{{ .Release.Namespace }}:{{ .Values.kafka.service.externalPort }}
+   Zookeeper nodes: {{ template "zkname" . }}.{{ .Release.Namespace }}:{{ .Values.zookeeper.service.externalPort }}

--- a/kafka/templates/_helpers.tpl
+++ b/kafka/templates/_helpers.tpl
@@ -16,12 +16,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Create the name of the service account to use
+Create a default fully qualified app name for zookeeper.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
+{{- define "zkname" -}}
+{{- $name := default "zookeeper" .Values.zookeeperNameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/kafka/templates/kafka-deployment.yaml
+++ b/kafka/templates/kafka-deployment.yaml
@@ -1,8 +1,7 @@
-{{- if .Values.create.faas -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-kafka
+  name: {{ template "fullname" . }}
   labels:
     app: {{ template "name" . }}
     component: kafka
@@ -19,7 +18,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}-kafka
+        - name: {{ .Chart.Name }}
           image: "{{ .Values.kafka.image.repository }}:{{ .Values.kafka.image.tag }}"
           imagePullPolicy: {{ .Values.kafka.image.pullPolicy }}
           ports:
@@ -34,5 +33,4 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: KAFKA_ZOOKEEPER_CONNECT
-              value: {{ template "fullname" . }}-zookeeper:2181
-{{- end -}}
+              value: {{ template "zkname" . }}:2181

--- a/kafka/templates/kafka-service.yaml
+++ b/kafka/templates/kafka-service.yaml
@@ -1,8 +1,7 @@
-{{- if .Values.create.faas -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-kafka
+  name: {{ template "fullname" . }}
   labels:
     app: {{ template "name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -19,4 +18,3 @@ spec:
     app: {{ template "name" . }}
     component: kafka-broker
     release: {{ .Release.Name }}
-{{- end -}}

--- a/kafka/templates/zookeeper-deployment.yaml
+++ b/kafka/templates/zookeeper-deployment.yaml
@@ -1,8 +1,7 @@
-{{- if .Values.create.faas -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-zookeeper
+  name: {{ template "zkname" . }}
   labels:
     app: {{ template "name" . }}
     component: zookeeper
@@ -29,4 +28,3 @@ spec:
             value: "1"
           - name: ZOOKEEPER_SERVER_1
             value: {{ template "fullname" . }}-zookeeper
-{{- end -}}

--- a/kafka/templates/zookeeper-service.yaml
+++ b/kafka/templates/zookeeper-service.yaml
@@ -1,8 +1,7 @@
-{{- if .Values.create.faas -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-zookeeper
+  name: {{ template "zkname" . }}
   labels:
     app: {{ template "name" . }}
     component: zookeeper
@@ -20,4 +19,3 @@ spec:
     app: {{ template "name" . }}
     component: zookeeper
     release: {{ .Release.Name }}
-{{- end -}}

--- a/kafka/values.yaml
+++ b/kafka/values.yaml
@@ -1,0 +1,25 @@
+# Default values for riff.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+zookeeper:
+  replicaCount: 1
+  image:
+    repository: wurstmeister/zookeeper
+    tag: 3.4.6
+    pullPolicy: IfNotPresent
+  service:
+    name: zookeeper
+    type: ClusterIP
+    externalPort: 2181
+    internalPort: 2181
+kafka:
+  replicaCount: 1
+  image:
+    repository: wurstmeister/kafka
+    tag: 0.11.0.1
+    pullPolicy: IfNotPresent
+  service:
+    name: kafka
+    type: ClusterIP
+    externalPort: 9092
+    internalPort: 9092

--- a/riff/Chart.yaml
+++ b/riff/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: riff is for functions - a FaaS for Kubernetes
 name: riff
-version: 0.0.3
-appVersion: 0.0.3
+version: 0.0.4-snapshot
+appVersion: 0.0.4-snapshot
 home: https://projectriff.io/
 icon: https://raw.githubusercontent.com/projectriff/projectriff.io/master/images/riff.png

--- a/riff/templates/function-controller-deployment.yaml
+++ b/riff/templates/function-controller-deployment.yaml
@@ -40,8 +40,8 @@ spec:
             - containerPort: 8080
           env:
           - name: KAFKA_BROKERS
-            value: {{ template "fullname" . }}-kafka:9092
+            value: {{ .Values.kafka.broker.nodes }}
           - name: RIFF_FUNCTION_SIDECAR_TAG
             value: {{ .Values.functionController.sidecar.image.tag }}
-      serviceAccountName: {{ template "fullname" . }}-sa
+      serviceAccountName: {{ template "serviceAccountName" . }}
 {{- end -}}

--- a/riff/templates/http-gateway-deployment.yaml
+++ b/riff/templates/http-gateway-deployment.yaml
@@ -37,5 +37,6 @@ spec:
             - containerPort: 8080
           env:
           - name: KAFKA_BROKERS
-            value: {{ template "fullname" . }}-kafka:9092
+            value: {{ .Values.kafka.broker.nodes }}
+      serviceAccountName: {{ template "serviceAccountName" . }}
 {{- end -}}

--- a/riff/templates/rbac.yaml
+++ b/riff/templates/rbac.yaml
@@ -1,18 +1,34 @@
 {{- if .Values.create.faas -}}
-{{ if .Values.create.rbac }}
+{{- if .Values.rbac.create -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
 metadata:
-  name: {{ template "fullname" . }}-cluster-role
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["projectriff.io"]
+    resources: ["functions", "topics"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
 metadata:
-  name: {{ template "fullname" . }}-role
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 rules:
   - apiGroups: [""]
     resources: ["services", "pods"]
@@ -27,26 +43,36 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
 metadata:
-  name: {{ template "fullname" . }}-cluster-rb
-subjects:
-- kind: ServiceAccount
-  name: {{ template "fullname" . }}-sa
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 roleRef:
   kind: ClusterRole
-  name: {{ template "fullname" . }}-cluster-role
+  name: {{ template "fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
 metadata:
-  name: {{ template "fullname" . }}-rb
-subjects:
-- kind: ServiceAccount
-  name: {{ template "fullname" . }}-sa
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 roleRef:
   kind: Role
-  name: {{ template "fullname" . }}-role
+  name: {{ template "fullname" . }}
   apiGroup: rbac.authorization.k8s.io
-{{ end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "serviceAccountName" . }}
+{{- end -}}
 {{- end -}}

--- a/riff/templates/service-account.yaml
+++ b/riff/templates/service-account.yaml
@@ -1,6 +1,13 @@
 {{- if .Values.create.faas -}}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "fullname" . }}-sa
+  name: {{ template "serviceAccountName" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end -}}
 {{- end -}}

--- a/riff/templates/topic-controller-deployment.yaml
+++ b/riff/templates/topic-controller-deployment.yaml
@@ -40,6 +40,6 @@ spec:
             - containerPort: 8080
           env:
           - name: KAFKA_ZK_NODES
-            value: {{ template "fullname" . }}-zookeeper:2181
-      serviceAccountName: {{ template "fullname" . }}-sa
+            value: {{ .Values.kafka.zookeeper.nodes }}
+      serviceAccountName: {{ template "serviceAccountName" . }}
 {{- end -}}

--- a/riff/values.yaml
+++ b/riff/values.yaml
@@ -4,53 +4,49 @@
 create:
   crd: true
   faas: true
-  rbac: false
+
 rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
   apiVersion: v1beta1
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
 functionController:
   replicaCount: 1
   image:
     repository: projectriff/function-controller
-    tag: 0.0.3
+    tag: 0.0.4-build.5
     pullPolicy: IfNotPresent
   sidecar:
     image:
-      tag: 0.0.3
+      tag: 0.0.4-build.4 
+
 topicController:
   replicaCount: 1
   image:
     repository: projectriff/topic-controller
-    tag: 0.0.3
+    tag: 0.0.4-build.4
     pullPolicy: IfNotPresent
+
 httpGateway:
   replicaCount: 1
   image:
     repository: projectriff/http-gateway
-    tag: 0.0.3
+    tag: 0.0.4-build.7
     pullPolicy: IfNotPresent
   service:
     name: http
     type: LoadBalancer
     externalPort: 80
-zookeeper:
-  replicaCount: 1
-  image:
-    repository: wurstmeister/zookeeper
-    tag: 3.4.6
-    pullPolicy: IfNotPresent
-  service:
-    name: zookeeper
-    type: ClusterIP
-    externalPort: 2181
-    internalPort: 2181
+
 kafka:
-  replicaCount: 1
-  image:
-    repository: wurstmeister/kafka
-    tag: 0.11.0.1
-    pullPolicy: IfNotPresent
-  service:
-    name: kafka
-    type: ClusterIP
-    externalPort: 9092
-    internalPort: 9092
+  broker:
+    nodes: transport-kafka.riff-system:9092
+  zookeeper:
+    nodes: transport-zookeeper.riff-system:2181


### PR DESCRIPTION
- Making it possible to use the `incubator/kafka` chart as a Kafka replacement

- The kafka chart should be installed into a `riff-system` namespace and can be shared by multiple riff intallations

  - Create the `riff-system` namespace using:

    `kubectl create namespace riff-system`

  - Install the light-weight single-node kafka/zookeeper service provided by riff using:

    `helm install --name transport --namespace riff-system riffrepo/kafka`

  - Alternatively, install the three-node kafka/zookeeper service provided by the Kubeapps `incubator/kafka` chart using:

    `helm install --name transport --namespace riff-system incubator/kafka`

- The riff chart can be installed into the default namespace or any other namespace including the `riff-system` namespace

  - Install the riff service in the default namespace using:

    `helm install --name control riffrepo/riff --devel`

  - Alternatively, install the riff service in the `riff-system` namespace using:

    `helm install --name control --namespace riff-system riffrepo/riff --devel`

- The riff chart's rbac template now follows the [The Chart Best Practices Guide](https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices) from the Kubernetes Helm project.

  - the option for installing rbac resources is now named `rbac.create` and defaults to true. This means that any non-rbac install would need to specify `--set rbac.create=false`